### PR TITLE
Add watchify to be able to npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "request": "~2.42.0"
   },
   "devDependencies": {
-    "coffeeify": "~0.7.0"
+    "coffeeify": "~0.7.0",
+    "watchify": "~1.0.2"
   }
 }


### PR DESCRIPTION
I had to add this dev dependency to get the thing to even `npm run dev`.

This dependency wasn't specified in the package, and I didn't already have it installed globally.
