### PR TITLE
Add browserify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "coffeeify": "~0.7.0",
-    "watchify": "~1.0.2"
+    "watchify": "~1.0.2",
+    "browserify": "~5.11.2"
   }
 }


### PR DESCRIPTION
This is needed for people who don’t have it installed globally already, so they can use the `build` command.
